### PR TITLE
Use play class

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -1,0 +1,5 @@
+source /usr/local/etc/bash_completion.d/git-prompt.sh
+source /usr/local/etc/bash_completion.d/git-completion.bash
+GIT_PS1_SHOWDIRTYSTATE=true
+export PS1='\[\033[32m\]\u@\h\[\033[00m\]:\[\033[34m\]\w\[\033[31m\]$(__git_ps1)\[\033[00m\]\n\$ '
+

--- a/.bashrc
+++ b/.bashrc
@@ -1,5 +1,0 @@
-source /usr/local/etc/bash_completion.d/git-prompt.sh
-source /usr/local/etc/bash_completion.d/git-completion.bash
-GIT_PS1_SHOWDIRTYSTATE=true
-export PS1='\[\033[32m\]\u@\h\[\033[00m\]:\[\033[34m\]\w\[\033[31m\]$(__git_ps1)\[\033[00m\]\n\$ '
-

--- a/deck.rb
+++ b/deck.rb
@@ -34,6 +34,11 @@ class Deck
             puts "[ #{cards[n].mark} #{cards[n].number} ]"
         end
     end
+
+    def reset
+        @cards = @cards.shuffle
+        @@draw_count = 0
+    end
 end
 
 #deck = Deck.new

--- a/main.rb
+++ b/main.rb
@@ -109,13 +109,55 @@ while true # 再プレイのためのループ処理
             if player.burst?
                 break
             end
+        elsif command == 's'
+            # スタンド時の処理（ディーラーのターン）
+            puts 'ディーラーのターンです'
+            puts '先に進む為になにかキーを入力してください'
+            c = gets
+            # プレイヤーがブラックジャックだった場合のディーラーの処理 
+            if player.blackjack?
+                dealer.draw
+                dealer.show
+                if !dealer.blackjack?
+                    puts win_message
+                    break
+                else
+                    puts game_draw_message
+                    break
+                end
+            end
+            # プレイヤーに勝つまでディーラーはヒットし続ける処理
+            while player.total_score > dealer.total_score
+                dealer.draw
+                dealer.show
+                if dealer.burst?
+                    puts 'バースト！'
+                    puts win_message
+                    break
+                elsif dealer.total_score == 21 && player.total_score == 21
+                    break
+                end
+            end
+            if dealer.burst? # バーストしていた場合処理処理終了
+                break
+            elsif dealer.total_score == 21 && player.total_score == 21 # お互い最大値に達していないか確認
+                puts game_draw_message
+                break
+            else
+                puts lose_message
+                break
+            end
+            command = nil
         else
             # h,s以外が入力されたときの処理
             puts error_message
             redo
         end
-        # スタンド時の処理（ディーラーのターン）
         if command == 's'
+        # スタンド時の処理（ディーラーのターン）
+            puts 'ディーラーのターンです'
+            puts '先に進む為になにかキーを入力してください'
+            c = gets
             # プレイヤーがブラックジャックだった場合のディーラーの処理 
             if player.blackjack?
                 dealer.draw

--- a/money.rb
+++ b/money.rb
@@ -1,0 +1,7 @@
+
+class Money
+    attr_accessor :money
+    def initialize
+        @stock = 20000
+    end
+end

--- a/play.rb
+++ b/play.rb
@@ -1,0 +1,17 @@
+require './player'
+
+class Play
+    attr_accessor :player, :dealer
+
+    def initialize
+        @player = Player.new
+        @dealer = Player.new(name: "ディーラー")
+        test
+    end
+
+    def test
+        @player.draw
+    end
+end
+
+Play.new

--- a/play.rb
+++ b/play.rb
@@ -1,16 +1,224 @@
 require './player'
+require './money'
 
 class Play
-    attr_accessor :player, :dealer
-
+    @@money = Money.new
     def initialize
         @player = Player.new
-        @dealer = Player.new(name: "ディーラー")
-        test
+        @dealer = Player.new(name: 'ディーラー')
+        play
     end
 
-    def test
-        @player.draw
+    def play
+        lose_message =<<~TEXT
+        あなたの負けです
+        TEXT
+        win_message =<<~TEXT
+        あなたの勝ちです
+        TEXT
+        game_draw_message =<<~TEXT
+        引き分けです
+        TEXT
+        error_message = "無効な文字です。もう一度入力してください"
+        
+        while true # 再プレイのためのループ処理
+            # 手札リセット
+            @player.reset
+            @dealer.reset
+            # 初ターンの処理
+            puts "ようこそ、ブラックジャックへ"
+            puts "カードを配ります"
+            @player.draw
+            @player.draw
+            @dealer.draw  
+            @dealer.show
+            # ブラックジャックテスト
+            # @dealer.reset
+            # @dealer.in_blackjac 
+            # @dealer.show
+            # @player.reset
+            # @player.in_blackjack
+            # @player.show
+
+            # プレイヤーがブラックジャックじゃないか確認の処理
+            if @player.blackjack?
+                    puts "ブラックジャック！"
+                    @player.show
+            else
+                @player.show
+                puts h_or_s_message =<<~TEXT
+                選択してください
+                Push「h」, ヒット
+                Push「s」, スタンド
+                TEXT
+            end
+
+            # ヒット、スタンドの処理（プレイヤーのターン）
+            while true
+                # ブラックジャックの場合は強制的にスタンドさせる処理
+                if @player.blackjack?
+                    command = 's'
+                else
+                    command = gets.chomp # ヒットかスタンドか選択
+                end
+                # ヒットの場合の処理
+                if command == "h"
+                    while true
+                        @player.draw
+                        if @player.burst? # バーストしていないか確認
+                            @player.show
+                            puts "バースト！！"
+                            puts lose_message
+                            break
+                        end
+                        # ドロー後のトータルスコアの確認
+                        @player.show
+                        # 最大値（２１）の場合は強制的にスタンドの処理
+                        if @player.total_score == 21
+                            puts 'トータルスコアが最大値に達しました'
+                            command = 's'
+                            break
+                        end
+                        # 最大値ではない場合は、再度ヒットするか処理
+                        puts "もう一度引きますか？"
+                        puts h_or_s_message
+                        while true
+                            command = gets.chomp # 再度、ヒットかスタンドの選択
+                            if command == 'h'
+                                break
+                            elsif command == 's'
+                                break
+                            else
+                                puts error_message
+                                redo
+                            end
+                        end
+                        # ヒットかスタンドの処理
+                        if command == 'h' 
+                            redo
+                        elsif command == 's'
+                            break
+                        end
+                    end
+                    # バースト時の強制終了処理
+                    if @player.burst?
+                        break
+                    end
+                elsif command == 's'
+                    # スタンド時の処理（ディーラーのターン）
+                    puts 'ディーラーのターンです'
+                    wait
+                    # プレイヤーがブラックジャックだった場合のディーラーの処理 
+                    if @player.blackjack?
+                        @dealer.draw
+                        @dealer.show
+                        if !@dealer.blackjack?
+                            puts win_message
+                            break
+                        else
+                            puts game_draw_message
+                            break
+                        end
+                    end
+                    # プレイヤーに勝つまでディーラーはヒットし続ける処理
+                    while @player.total_score > @dealer.total_score
+                        @dealer.draw
+                        @dealer.show
+                        wait
+                        if @dealer.burst?
+                            puts 'バースト！'
+                            puts win_message
+                            break
+                        elsif @dealer.total_score == 21 && @player.total_score == 21
+                            break
+                        end
+                    end
+                    if @dealer.burst? # バーストしていた場合処理処理終了
+                        break
+                    elsif @dealer.total_score == 21 && @player.total_score == 21 # お互い最大値に達していないか確認
+                        puts game_draw_message
+                        break
+                    else
+                        puts lose_message
+                        break
+                    end
+                    command = nil
+                else
+                    # h,s以外が入力されたときの処理
+                    puts error_message
+                    redo
+                end
+                if command == 's'
+                # スタンド時の処理（ディーラーのターン）
+                    puts 'ディーラーのターンです'
+                    wait
+                    # プレイヤーがブラックジャックだった場合のディーラーの処理 
+                    if @player.blackjack?
+                        @dealer.draw
+                        @dealer.show
+                        if !@dealer.blackjack?
+                            puts win_message
+                            break
+                        else
+                            puts game_draw_message
+                            break
+                        end
+                    end
+                    # プレイヤーに勝つまでディーラーはヒットし続ける処理
+                    while @player.total_score > @dealer.total_score
+                        @dealer.draw
+                        @dealer.show
+                        wait
+                        if @dealer.burst?
+                            puts 'バースト！'
+                            puts win_message
+                            break
+                        elsif @dealer.total_score == 21 && @player.total_score == 21
+                            break
+                        end
+                    end
+                    if @dealer.burst? # バーストしていた場合処理処理終了
+                        break
+                    elsif @dealer.total_score == 21 && @player.total_score == 21 # お互い最大値に達していないか確認
+                        puts game_draw_message
+                        break
+                    else
+                        puts lose_message
+                        break
+                    end
+                end
+            end
+            # 再プレイの処理
+            puts <<~TEXT
+            もう一回遊びますか？
+            選択してください
+            Push「h」, はい
+            Push「s」, いいえ
+            TEXT
+            while true
+                command = gets.chomp # 再プレイするか選択
+                if command == "h"
+                    command = nil
+                    break
+                elsif command == "s"
+                    break
+                else
+                    puts error_message
+                    redo
+                end
+            end
+            # 再プレイの処理
+            if command == nil
+                redo
+            else
+                break
+            end
+        end
+    end
+
+    def wait(words='Enterキーを押してください')
+        puts words
+        c = gets
     end
 end
 

--- a/player.rb
+++ b/player.rb
@@ -36,11 +36,11 @@ class Player
         end
         a
     end
-
-    # テスト用メソッド
-
-    def test
-        puts "テストーーーーーー"
+    
+    def reset
+        self.hands = []
+        self.total_score = 0
+        @@deck.reset
     end
 
     def total_score_calc
@@ -53,11 +53,13 @@ class Player
         end
         @total_score
     end
+    # テスト用メソッド
 
-    def reset
-        self.hands = []
-        self.total_score = 0
+    def test
+        puts "テストーーーーーー"
     end
+
+
 
     def reset_score
         self.total_score = 0

--- a/test/test.rb
+++ b/test/test.rb
@@ -1,5 +1,6 @@
 require 'minitest/autorun'
 require './player'
+require './money'
 class BlackJackTest < Minitest::Test
     # テストカードのマークは「 ♦︎ 」で統一
     @@test_J      = Card.new('♦︎', 'J')


### PR DESCRIPTION
プレイクラスへの移行は完了。
引き分け時に負けてしまう、バグがあるので次回修正する。
あとはパーツごとに分ける。
特にディーラーターンが全く同じ記述になっているので、
プレイクラスのメソッドにして、playメソッドの
記述を簡潔にする。